### PR TITLE
🐛 fix: db migration 'ON CASCADE'

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -88,6 +88,72 @@ def apply_startup_migrations():
                 text("ALTER TABLE user_level_history ADD COLUMN sample_count INT NULL")
             )
 
+        # --- Ensure FK constraints referencing users use ON DELETE CASCADE ---
+        # For tables that reference users.id, alter the foreign key to cascade on delete.
+        # This mimics the lightweight startup-migration approach used elsewhere.
+        tables_with_user_fk = [
+            "generated_contents",
+            "vocab_entries",
+            "user_level_history",
+            "study_sessions",
+            "user_achievements",
+        ]
+
+        for tbl in tables_with_user_fk:
+            try:
+                fks = inspector.get_foreign_keys(tbl)
+            except Exception:
+                # table may not exist yet in CI/dev DB; skip
+                continue
+
+            for fk in fks:
+                # identify FKs that reference users(id)
+                referred_table = fk.get("referred_table") or fk.get("referred_table_name")
+                constrained_columns = fk.get("constrained_columns") or fk.get("constrained_column")
+                if not referred_table or not constrained_columns:
+                    continue
+                if referred_table != "users":
+                    continue
+                if "user_id" not in constrained_columns:
+                    continue
+
+                fk_name = fk.get("name")
+                if not fk_name:
+                    # fallback: construct a name (not ideal) - skip if unnamed
+                    continue
+
+                # Check current ON DELETE rule via information_schema
+                try:
+                    row = conn.execute(
+                        text(
+                            "SELECT DELETE_RULE FROM information_schema.REFERENTIAL_CONSTRAINTS "
+                            "WHERE CONSTRAINT_SCHEMA = DATABASE() AND CONSTRAINT_NAME = :name AND TABLE_NAME = :table"
+                        ),
+                        {"name": fk_name, "table": tbl},
+                    ).fetchone()
+                except Exception:
+                    row = None
+
+                delete_rule = row[0] if row and len(row) > 0 else None
+
+                if delete_rule == "CASCADE":
+                    # already correct — log and continue
+                    print(f"[startup-migrate] FK `{fk_name}` on `{tbl}` already uses ON DELETE CASCADE")
+                    continue
+
+                # Drop and re-create FK with ON DELETE CASCADE
+                try:
+                    conn.execute(text(f"ALTER TABLE `{tbl}` DROP FOREIGN KEY `{fk_name}`"))
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE `{tbl}` ADD CONSTRAINT `{fk_name}` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE"
+                        )
+                    )
+                    print(f"[startup-migrate] altered FK `{fk_name}` on `{tbl}` to ON DELETE CASCADE")
+                except Exception as e:
+                    # Best-effort: log and continue; CI/dev environments may differ
+                    print(f"[startup-migrate] failed to alter FK {fk_name} on {tbl}: {e}")
+
 
 def get_db():
     db = SessionLocal()


### PR DESCRIPTION
### PR Title: 🐛 fix: db migration 'ON CASCADE'
#### Related Issue(s):
Link or reference any related issues or tickets.
#### PR Description:
유저 삭제 시에 user_id를 fk로 해서 참조하고 있는 엔트리가 있으면 유저 삭제가 실패하는 이슈가 있어서 on cascade
db migration 하는 코드를 작성해놓았습니다. 

##### Changes Included:
- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.

---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.

---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
